### PR TITLE
Fix the keycloak invalid version

### DIFF
--- a/tests/keycloak_postgres.yaml
+++ b/tests/keycloak_postgres.yaml
@@ -15,7 +15,7 @@ services:
       always
 
   keycloak:
-    image: docker.io/jboss/keycloak:16.0.1   # Locally built with `build_keycloak_m1.sh` as the current images do not support the architecture
+    image: docker.io/jboss/keycloak:16.1.0   # Locally built with `build_keycloak_m1.sh` as the current images do not support the architecture
     volumes:
       - ./realm-export.json:/opt/jboss/keycloak/imports/realm-export.json
     command:


### PR DESCRIPTION
Fix the keycloak invalid version on docker-compose from 16.0.1 to 16.1.0