### PR TITLE
Fix tests for configurable admin-client

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,6 +11,7 @@ class BaseTestClass:
             server_url="http://localhost:8085/auth",
             client_id="test-client",
             client_secret="GzgACcJzhzQ4j8kWhmhazt7WSdxDVUyE",
+            admin_client_id="admin-cli",
             admin_client_secret="BIcczGsZ6I8W5zf0rZg5qSexlloQLPKB",
             realm="Test",
             callback_uri="http://localhost:8081/callback"


### PR DESCRIPTION
With this `pytest ./tests` passes all tests.

Signed-off-by: Thomas Darimont <thomas.darimont@googlemail.com>