### PR TITLE
FastAPIKeycloak Timeout

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4,6 +4,7 @@ import pytest as pytest
 from fastapi import FastAPI
 from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError
+from requests import ReadTimeout
 
 from fastapi_keycloak import HTTPMethod
 from fastapi_keycloak.model import KeycloakRole
@@ -55,6 +56,14 @@ class TestAPIIntegration(BaseTestClass):
     def test_proxy(self, idp):
         response = idp.proxy(relative_path="/realms/Test", method=HTTPMethod.GET)
         assert type(response.json()) == dict
+
+    def test_timeout(self, idp):
+        idp.timeout = 0.001
+        try:
+            idp.proxy(relative_path="/realms/Test", method=HTTPMethod.GET)
+            assert False
+        except ReadTimeout:
+            assert True
 
     def test_get_all_roles_and_get_roles(self, idp):
         roles: List[KeycloakRole] = idp.get_all_roles()


### PR DESCRIPTION
My team is using this lib in a commercial project to connect Keycloak from Fastapi and we observed this lib doesn't use timeout in connection to Keycloak, to avoid that I wrote this:
```
class CustomTimeout(TimeoutSauce):
    def __init__(self, *args, **kwargs):
        if kwargs['connect'] is None:
            kwargs['connect'] = 5
        if kwargs['read'] is None:
            kwargs['read'] = 5
        super().__init__(*args, **kwargs)


requests.adapters.TimeoutSauce = CustomTimeout
IDP = FastAPIKeycloak(
    server_url=KEYCLOAK_SERVER_URL,
    client_id=KEYCLOAK_CLIENT_ID,
    client_secret=KEYCLOAK_CLIENT_SECRET,
    admin_client_secret=KEYCLOAK_ADMIN_CLIENT_SECRET,
    realm=KEYCLOAK_REALM,
    callback_uri=KEYCLOAK_CALLBACK_URI,
)
```
And decided to add timeout to FastAPIKeycloak init. Code checked and all tests passed 

Please review my PR and approve if it is okay for you to see timeout in this lib
