### PR TITLE
Throws a 404 when a user lookup fails.

### DIFF
--- a/fastapi_keycloak/api.py
+++ b/fastapi_keycloak/api.py
@@ -21,6 +21,7 @@ from fastapi_keycloak.exceptions import (
     UpdatePasswordException,
     UpdateProfileException,
     UpdateUserLocaleException,
+    UserNotFound,
     VerifyEmailException,
 )
 from fastapi_keycloak.model import (
@@ -849,6 +850,11 @@ class FastAPIKeycloak:
             response = self._admin_request(
                 url=f"{self.users_uri}/{user_id}", method=HTTPMethod.GET
             )
+            if response.status_code == status.HTTP_404_NOT_FOUND:
+                raise UserNotFound(
+                    status_code = status.HTTP_404_NOT_FOUND,
+                    reason=f"User with user_id[{user_id}] was not found"
+                )
             return KeycloakUser(**response.json())
 
     @result_or_error(response_model=KeycloakUser)

--- a/fastapi_keycloak/exceptions.py
+++ b/fastapi_keycloak/exceptions.py
@@ -14,6 +14,17 @@ class KeycloakError(Exception):
         self.reason = reason
         super().__init__(f"HTTP {status_code}: {reason}")
 
+class UserNotFound(Exception):
+    """Thrown when a user lookup fails.
+
+    Attributes:
+        status_code (int): The status code of the response received
+        reason (str): The reason why the requests did fail
+    """
+    def __init__(self, status_code: int, reason: str):
+        self.status_code = status_code
+        self.reason = reason
+        super().__init__(f"HTTP {status_code}: {reason}")
 
 class MandatoryActionException(HTTPException):
     """Throw if the exchange of username and password for an access token fails"""

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -9,6 +9,7 @@ from fastapi_keycloak.exceptions import (
     UpdatePasswordException,
     UpdateProfileException,
     UpdateUserLocaleException,
+    UserNotFound,
     VerifyEmailException,
 )
 from fastapi_keycloak.model import (
@@ -445,3 +446,10 @@ class TestAPIFunctional(BaseTestClass):
 
         # Clean up
         idp.delete_user(user_id=user.id)
+
+    def test_user_not_found_exception(self, idp):
+
+        with pytest.raises(
+            UserNotFound
+        ):  # Expect the get to fail due to anon existant user
+            u = idp.get_user(user_id="some_non_existant_user_id")


### PR DESCRIPTION
I was also bitten by the same bug as mentioned to #53, so I tried to fix it.

Unfortunately the instructions were not very clear on how to run the actual tests.

I could run the start_infra.sh to start the containers, but then what? How do I generate the required `test_coverage.xml` file?

Any feedback welcome!

Relates to #53