### PR TITLE
Move the exception of missing 'realm_access section' into the model itself

### DIFF
--- a/fastapi_keycloak/api.py
+++ b/fastapi_keycloak/api.py
@@ -259,11 +259,6 @@ class FastAPIKeycloak:
             decoded_token = self._decode_token(token=token, audience="account")
             user = OIDCUser.parse_obj(decoded_token)
             if required_roles:
-                if not user.realm_access:  # in cases where there are no roles in realm accessing
-                    raise HTTPException(
-                        status_code=status.HTTP_403_FORBIDDEN,
-                        detail=f"Role(s) {', '.join(required_roles)} is required to perform this action",
-                    )
                 for role in required_roles:
                     if role not in user.roles:
                         raise HTTPException(

--- a/fastapi_keycloak/model.py
+++ b/fastapi_keycloak/model.py
@@ -121,9 +121,7 @@ class OIDCUser(BaseModel):
         if not self.realm_access:
             raise KeycloakError(
                 status_code=404,
-                reason="'realm_access' section missing on the provided access token. \
-                HINT: enable 'Full Scope Allowed' on the 'client Scope Mappings', \
-                or manually assign the realm roles to scope",
+                reason="The 'realm_access' section of the provided access token is missing",
             )
         try:
             return self.realm_access["roles"]

--- a/fastapi_keycloak/model.py
+++ b/fastapi_keycloak/model.py
@@ -118,6 +118,13 @@ class OIDCUser(BaseModel):
         Returns:
             List[str]: If the realm access dict contains roles
         """
+        if not self.realm_access:
+            raise KeycloakError(
+                status_code=404,
+                reason="'realm_access' section missing on the provided access token. \
+                HINT: enable 'Full Scope Allowed' on the 'client Scope Mappings', \
+                or manually assign the realm roles to scope",
+            )
         try:
             return self.realm_access["roles"]
         except KeyError as e:


### PR DESCRIPTION
With this patch, if the realm_access section is missing in the access token, then:
```
user=idp.get_current_user(...)
print(user.roles)
```
will raise an exception describing the error.
The current behavior is:

```
....
    return self.realm_access["roles"]
TypeError: 'NoneType' object is not subscriptable
....
```