### PR TITLE
Set None as default for Optional fields

### DIFF
--- a/fastapi_keycloak/model.py
+++ b/fastapi_keycloak/model.py
@@ -52,15 +52,15 @@ class KeycloakUser(BaseModel):
     enabled: bool
     totp: bool
     emailVerified: bool
-    firstName: Optional[str]
-    lastName: Optional[str]
-    email: Optional[str]
+    firstName: Optional[str] = None
+    lastName: Optional[str] = None
+    email: Optional[str] = None
     disableableCredentialTypes: List[str]
     requiredActions: List[str]
-    realmRoles: Optional[List[str]]
+    realmRoles: Optional[List[str]] = None
     notBefore: int
     access: dict
-    attributes: Optional[dict]
+    attributes: Optional[dict] = None
 
 
 class UsernamePassword(BaseModel):
@@ -97,19 +97,19 @@ class OIDCUser(BaseModel):
     details. This is a mere proxy object.
     """
 
-    azp: Optional[str]
+    azp: Optional[str] = None
     sub: str
     iat: int
     exp: int
-    scope: Optional[str]
+    scope: Optional[str] = None
     email_verified: bool
-    name: Optional[str]
-    given_name: Optional[str]
-    family_name: Optional[str]
-    email: Optional[str]
-    preferred_username: Optional[str]
-    realm_access: Optional[dict]
-    resource_access: Optional[dict]
+    name: Optional[str] = None
+    given_name: Optional[str] = None
+    family_name: Optional[str] = None
+    email: Optional[str] = None
+    preferred_username: Optional[str] = None
+    realm_access: Optional[dict] = None
+    resource_access: Optional[dict] = None
     extra_fields: dict = Field(default_factory=dict)
 
     @property
@@ -229,9 +229,9 @@ class KeycloakGroup(BaseModel):
 
     id: str
     name: str
-    path: Optional[str]
-    realmRoles: Optional[List[str]]
-    subGroups: Optional[List["KeycloakGroup"]]
+    path: Optional[str] = None
+    realmRoles: Optional[List[str]] = None
+    subGroups: Optional[List["KeycloakGroup"]] = None
 
 
 KeycloakGroup.update_forward_refs()


### PR DESCRIPTION
Optional and Required have different semantics, and the [Pydantic v2 cleanup](https://docs.pydantic.dev/latest/blog/pydantic-v2/#required-vs-nullable-cleanup) makes the fields required unless None is set as default value.

Without adding `= None` in those optional fields, the library fails, e.g.:

```
pydantic_core._pydantic_core.ValidationError: 2 validation errors for KeycloakUser
realmRoles
  Field required [type=missing, input_value={'id': '898e45fa-d868-4b3...: True, 'manage': True}}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.1.2/v/missing
attributes
  Field required [type=missing, input_value={'id': '898e45fa-d868-4b3...: True, 'manage': True}}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.1.2/v/missing
```