### PR TITLE
Add `get_group_members` support

### DIFF
--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -24,8 +24,10 @@ FastAPI Keycloak enables you to do the following things without writing a single
 - Verify identities and roles of users with Keycloak
 - Get a list of available identity providers
 - Create/read/delete users
+- Create/read/delete groups
 - Create/read/delete roles
 - Assign/remove roles from users
+- Assign/remove users from groups
 - Implement the `password` or the `authorization_code` flow (login/callback/logout)
 
 ## Example

--- a/fastapi_keycloak/api.py
+++ b/fastapi_keycloak/api.py
@@ -691,6 +691,25 @@ class FastAPIKeycloak:
             url=f"{self.users_uri}/{user_id}/groups",
             method=HTTPMethod.GET,
         )
+    
+    @result_or_error(response_model=KeycloakUser, is_list=True)
+    def get_group_members(self, group_id: str):
+        """Get all members of a group.
+        
+        Args:
+            group_id (str): ID of the group of interest
+
+        Returns:
+            List[KeycloakUser]: All users in the group. Note that
+            the user objects returned are not fully populated.
+        
+        Raises:
+            KeycloakError: If the resulting response is not a successful HTTP-Code (>299)
+        """
+        return self._admin_request(
+            url=f"{self.groups_uri}/{group_id}/members",
+            method=HTTPMethod.GET,
+        )
 
     @result_or_error()
     def remove_user_group(self, user_id: str, group_id: str) -> dict:

--- a/fastapi_keycloak/model.py
+++ b/fastapi_keycloak/model.py
@@ -59,7 +59,7 @@ class KeycloakUser(BaseModel):
     requiredActions: List[str]
     realmRoles: Optional[List[str]]
     notBefore: int
-    access: dict
+    access: Optional[dict] = None
     attributes: Optional[dict]
 
 


### PR DESCRIPTION
Keycloak supports a ["get group members" mechanism](https://www.keycloak.org/docs-api/23.0.3/rest-api/index.html#_groups).

Supporting it is straightforward, only thing to be aware of is the `access` attribute: my tests showed it as non-populated (missing from the response). Setting it as Optional is a closer match to the [UserRepresentation](https://www.keycloak.org/docs-api/23.0.3/rest-api/index.html#UserRepresentation) and should not break anything.