### PR TITLE
Trigger Test-Suite on Pull Requests

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -2,6 +2,8 @@ name: Test-Suite
 
 on:
   workflow_dispatch:
+  pull_request:
+    types: [review_requested]
   push:
 
 jobs:


### PR DESCRIPTION
It seems that Test-Suite cannot be triggered from pull requests, and thus they cannot be accepted through the proper steps.